### PR TITLE
add pagefind search indexing to docker-publish

### DIFF
--- a/Dockerfile-publish
+++ b/Dockerfile-publish
@@ -6,5 +6,6 @@ COPY . /app/
 WORKDIR /app/
 RUN npm install --production=false
 RUN git config --global --add safe.directory /app/
+RUN npm_config_yes=true npx pagefind --source "." --bundle-dir ../static/_pagefind
 
 CMD ["serve", "--cleanDestinationDir", "--themesDir", "../..", "--disableFastRender", "--ignoreCache", "--watch"]


### PR DESCRIPTION
## What is the motivation?
Add pagefind seach indexing to the dockerfile-publish.

## What does this change do?
Enables the indexing of the search functionality in the docker build.

## What is your testing strategy?
Tested changes locally. 

## Have you read the [Contributing Guidelines](CONTRIBUTING.md)?
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
