### PR TITLE
Add type to dns to fix empty type error

### DIFF
--- a/content/en/docs/reference/humanitec-extension.md
+++ b/content/en/docs/reference/humanitec-extension.md
@@ -60,8 +60,10 @@ spec:
             type: prefix
             port: 80
 resources:
-  db:
-    scope: external
   dns:
+    type: dns
     scope: shared
+  db:
+    type: mysql
+    ...
 ```


### PR DESCRIPTION
The current example does not specify the type for the dns resource which causes an error when trying to deploy a draft like this.

Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Tried following the docs and ran into the error described above.

## What does this change do?

Change example config to valid config.

## What is your testing strategy?

Works for me 😎 

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](CONTRIBUTING.md)
