### PR TITLE
Adds the retry flag

### DIFF
--- a/content/en/docs/reference/score-cli/score-humanitec delta.md
+++ b/content/en/docs/reference/score-cli/score-humanitec delta.md
@@ -89,6 +89,12 @@ Specifies the path to the override file.
 
 Default: `./overrides.score.yaml`
 
+### `--retry`
+
+If set, the command will retry the deployment if it fails.
+
+Default: `false`
+
 ### `--token`
 
 Specifies a Humanitec API authentication token.


### PR DESCRIPTION
### `--retry`

If set, the command will retry the deployment if it fails.

Default: `false`

TODO: Need to document about the 15-minute time constraint on deployments.


- DOCS 201