### PR TITLE
remove unsupported schema from probe

### DIFF
--- a/content/en/docs/reference/score-spec-reference.md
+++ b/content/en/docs/reference/score-spec-reference.md
@@ -319,12 +319,10 @@ containers:
 
     livenessProbe:                          # (Optional) Liveness probe
       httpGet:                              #    - Only HTTP GET is supported
-        schema: http                        #    - Specify the schema (http or https)
         path: /alive
         port: 8080
     readinessProbe:                         # (Optional) Readiness probe
       httpGet:                              #    - Only HTTP GET is supported
-        schema: http                        #    - Specify the schema (http or https)
         path: /ready
         port: 8080
         httpHeaders:                        #    - (Optional) HTTP Headers to include


### PR DESCRIPTION
`schema` is not supported and using the example returns an error: `Additional property schema is not allowed`