### PR TITLE
fix(content): fixed the description of liveness and readiness probe in the spec

### DIFF
--- a/content/en/docs/reference/score-spec-reference.md
+++ b/content/en/docs/reference/score-spec-reference.md
@@ -276,27 +276,17 @@ readinessProbe:
 
 `livenessProbe`: indicates if the container is running.
 
-- `scheme`: specifies the identifier used for connecting to the host.
-  - Defaults: `HTTP`
-  - Valid values: `HTTP` | `HTTPS`
-
 - `httpGet`: performs an HTTP `Get` on a specified path and port.
+  - `scheme`: specifies the identifier used for connecting to the host.
+    - Defaults: `HTTP`
+    - Valid values: `HTTP` | `HTTPS`
   - `path`: specifies a path for the HTTP `Get` method.
   - `port`: specifies a port for the HTTP `Get` method.
-
-`readinessProbe`: indicates if the container is ready to respond to requests.
-
-- `scheme`: specifies the identifier used for connecting to the host.
-  - Defaults: `HTTP`
-  - Valid values: `HTTP` | `HTTPS`
-
-- `httpGet`: performs an HTTP `Get` on a specified path and port.
-  - `path`: specifies a path for the HTTP `Get` method.
-  - `port`: specifies a port for the HTTP `Get` method.
-
   - `httpHeaders`: headers to set in the request. Allows repeated headers.
     - `name`: custom header to set in the request.
     - `value`: specifies a value.
+
+`readinessProbe`: indicates if the container is ready to respond to requests. This has the same format as `livenessProbe`.
 
 ### Container example
 


### PR DESCRIPTION
See #64 for a description of the issue and a Before screenshot.

This change amends the documentation for the container probes.

After:

![image](https://github.com/score-spec/docs/assets/1651305/6fdd83f3-b8e9-47e9-bd90-7ec1e48aa112)

Tested by running the Dockerfile-publish container locally and taking the screenshot above.

## Have you read the [Contributing Guidelines](CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](CONTRIBUTING.md)
