### PR TITLE
fix(content): removed unknown hostIP field from docs

### DIFF
--- a/content/en/docs/reference/score-spec-reference.md
+++ b/content/en/docs/reference/score-spec-reference.md
@@ -157,7 +157,6 @@ service:
     port-name: string        # (required)
       port: integer          # (required)
       protocol: string       # (optional)
-      hostIP: integer        # (optional)
       targetPort: integer    # (optional)
 ```
 
@@ -169,8 +168,6 @@ service:
 
 - Defaults: `TCP`
 - Valid values: `SCTP` | `TCP` | `UDP`
-
-`hostIP`: describes the host IP to bind to.
 
 `targetPort`: describes the port to expose on the host. If the `targetPort` isn't specified, then it defaults to the required `port` property in the container.
 


### PR DESCRIPTION
See https://github.com/score-spec/schema/issues/7 for the initial description of this issue.

HostIP is not a field in the score schema, and is not supported by any implementation of score at the moment.

I think we should remove this for now, if it needs to be added it should be added first to the schema.