### PR TITLE
Import latest schema

### DIFF
--- a/schemas/score-v1b1.json
+++ b/schemas/score-v1b1.json
@@ -37,27 +37,9 @@
         "ports": {
           "description": "List of network ports published by the service.",
           "type": "object",
-          "additionalProperties": true,
           "minProperties": 1,
-          "patternProperties": {
-            "^*": {
-              "description": "The network port description.",
-              "type": "object",
-              "required": [
-                "targetPort"
-              ],
-              "additionalProperties": false,
-              "properties": {
-                "port": {
-                  "description": "The public service port.",
-                  "type": "number"
-                },
-                "targetPort": {
-                  "description": "The internal service port.",
-                  "type": "number"
-                }
-              }
-            }
+          "additionalProperties": {
+            "$ref": "#/$defs/servicePort"
           }
         }
       }
@@ -65,272 +47,309 @@
     "containers": {
       "description": "The declared Score Specification version.",
       "type": "object",
-      "additionalProperties": true,
       "minProperties": 1,
-      "patternProperties": {
-        "^*": {
-          "description": "The container name.",
-          "type": "object",
-          "required": [
-            "image"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "image": {
-              "description": "The image name and tag.",
-              "type": "string"
-            },
-            "command": {
-              "description": "If specified, overrides container entry point.",
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "string"
-              }
-            },
-            "args": {
-              "description": "If specified, overrides container entry point arguments.",
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "string"
-              }
-            },
-            "variables": {
-              "description": "The environment variables for the container.",
-              "type": "object",
-              "minProperties": 1,
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
-            "files": {
-              "description": "The extra files to mount.",
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "object",
-                "required": [
-                  "target"
-                ],
-                "properties": {
-                  "target": {
-                    "description": "The file path and name.",
-                    "type": "string"
-                  },
-                  "mode": {
-                    "description": "The file access mode.",
-                    "type": "string"
-                  },
-                  "source": {
-                    "description": "The relative or absolute path to the content file.",
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "content": {
-                    "description": "The inline content for the file.",
-                    "anyOf": [{
-                        "type": "string"
-                      }, {
-                        "deprecated": true,
-                        "type": "array",
-                        "minItems": 1,
-                        "items": {
-                          "type": "string"
-                        }
-                      }]
-                  },
-                  "noExpand": {
-                    "description": "If set to true, the placeholders expansion will not occur in the contents of the file.",
-                    "type": "boolean"
-                  }
-                },
-                "oneOf": [{ 
-                    "required": ["content"]
-                  }, { 
-                    "required": ["source"]
-                  }]
-              }
-            },
-            "volumes": {
-              "description": "The volumes to mount.",
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "object",
-                "required": [
-                  "source",
-                  "target"
-                ],
-                "properties": {
-                  "source": {
-                    "description": "The external volume reference.",
-                    "type": "string"
-                  },
-                  "path": {
-                    "description": "An optional sub path in the volume.",
-                    "type": "string"
-                  },
-                  "target": {
-                    "description": "The target mount on the container.",
-                    "type": "string"
-                  },
-                  "read_only": {
-                    "description": "Indicates if the volume should be mounted in a read-only mode.",
-                    "type": "boolean"
-                  }
-                }
-              }
-            },
-            "resources": {
-              "description": "The compute resources for the container.",
-              "type": "object",
-              "minProperties": 1,
-              "additionalProperties": false,
-              "properties": {
-                "limits": {
-                  "description": "The maximum allowed resources for the container.",
-                  "$ref": "#/properties/containers/definitions/resourcesLimits"
-                },
-                "requests": {
-                  "description": "The minimal resources required for the container.",
-                  "$ref": "#/properties/containers/definitions/resourcesLimits"
-                }
-              }
-            },
-            "livenessProbe": {
-              "description": "The liveness probe for the container.",
-              "$ref": "#/properties/containers/definitions/containerProbe"
-            },
-            "readinessProbe": {
-              "description": "The readiness probe for the container.",
-              "$ref": "#/properties/containers/definitions/containerProbe"
-            }
-          }
-        }
-      },
-      "definitions": {
-        "resourcesLimits": {
-          "description": "The compute resources limits.",
-          "type": "object",
-          "minProperties": 1,
-          "additionalProperties": false,
-          "properties": {
-            "memory": {
-              "description": "The memory limit.",
-              "type": "string"
-            },
-            "cpu": {
-              "description": "The CPU limit.",
-              "type": "string"
-            }
-          }
-        },
-        "containerProbe": {
-          "type": "object",
-          "minProperties": 1,
-          "additionalProperties": false,
-          "properties": {
-            "httpGet": {
-              "$ref": "#/properties/containers/definitions/httpProbe"
-            }
-          }
-        },
-        "httpProbe": {
-          "description": "An HTTP probe details.",
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "path"
-          ],
-          "properties": {
-            "host": {
-              "description": "Host name to connect to. Defaults to the container IP.",
-              "type": "string"
-            },
-            "scheme": {
-              "description": "Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.",
-              "type": "string",
-              "enum": [
-                "HTTP",
-                "HTTPS"
-              ]
-            },
-            "path": {
-              "description": "The path of the HTTP probe endpoint.",
-              "type": "string"
-            },
-            "port": {
-              "description": "The path of the HTTP probe endpoint.",
-              "type": "number"
-            },
-            "httpHeaders": {
-              "description": "Additional HTTP headers to send with the request",
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "name": {
-                    "description": "The HTTP header name.",
-                    "type": "string"
-                  },
-                  "value": {
-                    "description": "The HTTP header value.",
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        }
+      "additionalProperties": {
+        "$ref": "#/$defs/container"
       }
     },
     "resources": {
       "description": "The dependencies needed by the Workload.",
       "type": "object",
       "minProperties": 1,
-      "additionalProperties": true,
-      "patternProperties": {
-        "^*": {
-          "description": "The resource name.",
+      "additionalProperties": {
+        "$ref": "#/$defs/resource"
+      }
+    }
+  },
+  "$defs": {
+    "servicePort": {
+      "description": "The network port description.",
+      "type": "object",
+      "required": [
+        "port"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "port": {
+          "description": "The public service port.",
+          "type": "integer"
+        },
+        "protocol": {
+          "description": "The transport level protocol. Defaults to TCP.",
+          "type": "string"
+        },
+        "targetPort": {
+          "description": "The internal service port. This will default to 'port' if not provided.",
+          "type": "integer"
+        }
+      }
+    },
+    "resource": {
+      "description": "The resource name.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "description": "The resource in the target environment.",
+          "type": "string"
+        },
+        "class": {
+          "description": "A specialisation of the resource type.",
+          "type": "string",
+          "pattern": "^[a-z0-9](?:-?[a-z0-9]+)+$"
+        },
+        "metadata": {
+          "description": "The metadata for the resource.",
           "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "type"
-          ],
+          "minProperties": 1,
+          "additionalProperties": true,
           "properties": {
-            "type": {
-              "description": "The resource in the target environment.",
-              "type": "string"
-            },
-            "metadata": {
-              "description": "The metadata for the resource.",
+            "annotations": {
+              "description": "Annotations that apply to the property.",
               "type": "object",
               "minProperties": 1,
-              "additionalProperties": true,
-              "properties": {
-                "annotations": {
-                  "description": "Annotations that apply to the property.",
-                  "type": "object",
-                  "minProperties": 1,
-                  "additionalProperties": {
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "properties": {
+          "description": "DEPRECATED: The properties that can be referenced in other places in the Score Specification file.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "params": {
+          "description": "The parameters used to validate or provision the resource in the environment.",
+          "type": "object"
+        }
+      }
+    },
+    "resourcesLimits": {
+      "description": "The compute resources limits.",
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "memory": {
+          "description": "The memory limit.",
+          "type": "string"
+        },
+        "cpu": {
+          "description": "The CPU limit.",
+          "type": "string"
+        }
+      }
+    },
+    "container": {
+      "description": "The container name.",
+      "type": "object",
+      "required": [
+        "image"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "description": "The image name and tag.",
+          "type": "string"
+        },
+        "command": {
+          "description": "If specified, overrides container entry point.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "args": {
+          "description": "If specified, overrides container entry point arguments.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "variables": {
+          "description": "The environment variables for the container.",
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "files": {
+          "description": "The extra files to mount.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "target"
+            ],
+            "properties": {
+              "target": {
+                "description": "The file path and name.",
+                "type": "string"
+              },
+              "mode": {
+                "description": "The file access mode.",
+                "type": "string"
+              },
+              "source": {
+                "description": "The relative or absolute path to the content file.",
+                "type": "string",
+                "minLength": 1
+              },
+              "content": {
+                "description": "The inline content for the file.",
+                "anyOf": [
+                  {
                     "type": "string"
+                  },
+                  {
+                    "deprecated": true,
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string"
+                    }
                   }
-                }
+                ]
+              },
+              "noExpand": {
+                "description": "If set to true, the placeholders expansion will not occur in the contents of the file.",
+                "type": "boolean"
               }
             },
+            "oneOf": [
+              {
+                "required": [
+                  "content"
+                ]
+              },
+              {
+                "required": [
+                  "source"
+                ]
+              }
+            ]
+          }
+        },
+        "volumes": {
+          "description": "The volumes to mount.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "source",
+              "target"
+            ],
             "properties": {
-              "description": "DEPRECATED: The properties that can be referenced in other places in the Score Specification file.",
-              "type": [
-                "object",
-                "null"
-              ]
+              "source": {
+                "description": "The external volume reference.",
+                "type": "string"
+              },
+              "path": {
+                "description": "An optional sub path in the volume.",
+                "type": "string"
+              },
+              "target": {
+                "description": "The target mount on the container.",
+                "type": "string"
+              },
+              "read_only": {
+                "description": "Indicates if the volume should be mounted in a read-only mode.",
+                "type": "boolean"
+              }
+            }
+          }
+        },
+        "resources": {
+          "description": "The compute resources for the container.",
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": false,
+          "properties": {
+            "limits": {
+              "description": "The maximum allowed resources for the container.",
+              "$ref": "#/$defs/resourcesLimits"
             },
-            "params": {
-              "description": "The parameters used to validate or provision the resource in the environment.",
-              "type": "object"
+            "requests": {
+              "description": "The minimal resources required for the container.",
+              "$ref": "#/$defs/resourcesLimits"
+            }
+          }
+        },
+        "livenessProbe": {
+          "description": "The liveness probe for the container.",
+          "$ref": "#/$defs/containerProbe"
+        },
+        "readinessProbe": {
+          "description": "The readiness probe for the container.",
+          "$ref": "#/$defs/containerProbe"
+        }
+      }
+    },
+    "containerProbe": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "httpGet": {
+          "$ref": "#/$defs/httpProbe"
+        }
+      }
+    },
+    "httpProbe": {
+      "description": "An HTTP probe details.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "host": {
+          "description": "Host name to connect to. Defaults to the container IP.",
+          "type": "string"
+        },
+        "scheme": {
+          "description": "Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.",
+          "type": "string",
+          "enum": [
+            "HTTP",
+            "HTTPS"
+          ]
+        },
+        "path": {
+          "description": "The path of the HTTP probe endpoint.",
+          "type": "string"
+        },
+        "port": {
+          "description": "The path of the HTTP probe endpoint.",
+          "type": "integer"
+        },
+        "httpHeaders": {
+          "description": "Additional HTTP headers to send with the request",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "description": "The HTTP header name.",
+                "type": "string"
+              },
+              "value": {
+                "description": "The HTTP header value.",
+                "type": "string"
+              }
             }
           }
         }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The JSON schema displayed on the "Reference / schema reference" page is outdated.

## What does this change do?

This change imports the current schema from the [score-spec/schema ](https://github.com/score-spec/schema) repo. The docs page will automatically display the updated version.

## What is your testing strategy?

I used the `git subtree pull` command as specified in `schemas/README.md` to pull the latest version.
I compared the JSON files in both repos using `diff` and found no differences.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](CONTRIBUTING.md)
