### PR TITLE
fix: update embedded score specification and fix reference docs

### DIFF
--- a/content/en/docs/reference/score-spec-reference.md
+++ b/content/en/docs/reference/score-spec-reference.md
@@ -167,7 +167,7 @@ service:
 `protocol`: describes the transportation layer protocol.
 
 - Defaults: `TCP`
-- Valid values: `SCTP` | `TCP` | `UDP`
+- Valid values: `TCP` | `UDP`
 
 `targetPort`: describes the port to expose on the host. If the `targetPort` isn't specified, then it defaults to the required `port` property in the container.
 
@@ -202,21 +202,26 @@ command: []string
 args: []string
 variables: map[string]string
 files:
-  target: string
-  mode: string
-  content: string
-  source: string
-  noExpand: boolean
+  - target: string
+    mode: string
+    content: string
+    source: string
+    noExpand: boolean
 volumes:
-  source: string
-  path: string
-  target: string
-read_only: [true | false]
+  - target: string
+    source: string
+    path: string
+    readOnly: [true | false]
 resources:
-  limits: map[string]interface{}
-  requests: map[string]interface{}
+  limits:
+    cpu: string
+    memory: string
+  requests:
+    cpu: string
+    memory: string
 livenessProbe: ContainerProbeSpec
   httpGet:
+    scheme: [HTTP or HTTPS]
     path: string
     port: int
     httpHeaders:
@@ -224,7 +229,7 @@ livenessProbe: ContainerProbeSpec
       value: string
 readinessProbe:
   httpGet:
-    scheme: string
+    scheme: [HTTP or HTTPS]
     path: string
     port: int
     httpHeaders:
@@ -257,7 +262,7 @@ readinessProbe:
 - `source`: specifies external volume reference.
 - `path` specifies a sub path in the volume.
 - `target`: specifies a target mount on the container.
-- `read_only`: if true, mounts as read only.
+- `readOnly`: if true, mounts as read only.
 
 <!-- Optional CPU and memory resources needed -->
 
@@ -277,6 +282,7 @@ readinessProbe:
   - `scheme`: specifies the identifier used for connecting to the host.
     - Defaults: `HTTP`
     - Valid values: `HTTP` | `HTTPS`
+  - `host`: specifies the Hostname in the HTTP request. Defaults to the target IP address.
   - `path`: specifies a path for the HTTP `Get` method.
   - `port`: specifies a port for the HTTP `Get` method.
   - `httpHeaders`: headers to set in the request. Allows repeated headers.
@@ -313,7 +319,7 @@ containers:
     - source: ${resources.data}             #    - External volume reference
       path: sub/path                        #    - (Optional) Sub path in the volume
       target: /mnt/data                     #    - Target mount path on the container
-      read_only: true                       #    - (Optional) Mount as read-only
+      readOnly: true                       #    - (Optional) Mount as read-only
 
     resources:                              # (Optional) CPU and memory resources needed
       limits:                               #    - (Optional) Maximum allowed

--- a/schemas/Makefile
+++ b/schemas/Makefile
@@ -1,0 +1,45 @@
+# Disable all the default make stuff
+MAKEFLAGS += --no-builtin-rules
+.SUFFIXES:
+
+SCORE_EXAMPLES_DIR ?= ./samples/
+
+## Display help menu
+.PHONY: help
+help:
+	@echo Documented Make targets:
+	@perl -e 'undef $$/; while (<>) { while ($$_ =~ /## (.*?)(?:\n# .*)*\n.PHONY:\s+(\S+).*/mg) { printf "\033[36m%-30s\033[0m %s\n", $$2, $$1 } }' $(MAKEFILE_LIST) | sort
+
+# ------------------------------------------------------------------------------
+# NON-PHONY TARGETS
+# ------------------------------------------------------------------------------
+
+${GOPATH}/bin/jv:
+ifeq ($(GOPATH),)
+	$(error GOPATH must be set)
+endif
+	go install github.com/santhosh-tekuri/jsonschema/cmd/jv@latest
+
+# ------------------------------------------------------------------------------
+# PHONY TARGETS
+# ------------------------------------------------------------------------------
+
+.PHONY: .ALWAYS
+.ALWAYS:
+
+## Test that the score schema matches the json-schema reference
+.PHONY: test-schema
+test-schema: ${GOPATH}/bin/jv
+	${GOPATH}/bin/jv -assertformat -assertcontent https://json-schema.org/draft/2020-12/schema ./score-v1b1.json
+
+## Test that the given score examples in $SCORE_EXAMPLES_DIR match the schema
+.PHONY: test-examples
+test-examples: ${GOPATH}/bin/jv
+ifeq ($(SCORE_EXAMPLES_DIR),)
+	$(error SCORE_EXAMPLES_DIR must be set)
+endif
+	find ${SCORE_EXAMPLES_DIR} -name 'score*.yaml' -print -exec ${GOPATH}/bin/jv -assertformat -assertcontent ./score-v1b1.json {} \;
+
+## Run all tests
+.PHONY: test
+test: test-schema test-examples

--- a/schemas/samples/score-full.yaml
+++ b/schemas/samples/score-full.yaml
@@ -1,0 +1,70 @@
+apiVersion: score.dev/v1b1
+metadata:
+  name: example-workload-name123
+  extra-key: extra-value
+service:
+  ports:
+    port-one:
+      port: 1000
+      protocol: TCP
+      targetPort: 10000
+    port-two2:
+      port: 8000
+containers:
+  container-one1:
+    image: localhost:4000/repo/my-image:tag
+    command: ["/bin/sh", "-c"]
+    args: ["hello", "world"]
+    resources:
+      requests:
+        cpu: 1000m
+        memory: 10Gi
+      limits:
+        cpu: "0.24"
+        memory: 128M
+    variables:
+      SOME_VAR: some content here
+    files:
+    - target: /my/file
+      mode: "0600"
+      source: file.txt
+    - target: /my/other/file
+      content: |
+        some multiline
+        content
+    volumes:
+    - source: volume-name
+      target: /mnt/something
+      path: /sub/path
+      readOnly: false
+    - source: volume-two
+      target: /mnt/something-else
+    livenessProbe:
+      httpGet:
+        port: 8080
+        path: /livez
+    readinessProbe:
+      httpGet:
+        host: 127.0.0.1
+        port: 80
+        scheme: HTTP
+        path: /readyz
+        httpHeaders:
+        - name: SOME_HEADER
+          value: some-value-here
+  container-two2:
+    image: .
+resources:
+  resource-one1:
+    metadata:
+      annotations:
+        Default-Annotation: this is my annotation
+        prefix.com/Another-Key_Annotation.2: something else
+      extra-key: extra-value
+    type: Resource-One
+    class: default
+    params:
+      extra:
+        data: here
+  resource-two2:
+    type: Resource-Two

--- a/schemas/score-v1b1.json
+++ b/schemas/score-v1b1.json
@@ -4,7 +4,11 @@
   "title": "Score schema",
   "description": "Score workload specification",
   "type": "object",
-  "required": ["apiVersion", "metadata", "containers"],
+  "required": [
+    "apiVersion",
+    "metadata",
+    "containers"
+  ],
   "additionalProperties": false,
   "properties": {
     "apiVersion": {
@@ -15,7 +19,9 @@
     "metadata": {
       "description": "The metadata description of the Workload.",
       "type": "object",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "additionalProperties": true,
       "properties": {
         "name": {
@@ -76,7 +82,9 @@
     "servicePort": {
       "description": "The network port description.",
       "type": "object",
-      "required": ["port"],
+      "required": [
+        "port"
+      ],
       "additionalProperties": false,
       "properties": {
         "port": {
@@ -88,7 +96,10 @@
         "protocol": {
           "description": "The transport level protocol. Defaults to TCP.",
           "type": "string",
-          "enum": ["TCP", "UDP"]
+          "enum": [
+            "TCP",
+            "UDP"
+          ]
         },
         "targetPort": {
           "description": "The internal service port. This will default to 'port' if not provided.",
@@ -102,7 +113,9 @@
       "description": "The set of Resources associated with this Workload.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "description": "The Resource type. This should be a type supported by the Score implementations being used.",
@@ -164,7 +177,9 @@
     "container": {
       "description": "The specification of a Container within the Workload.",
       "type": "object",
-      "required": ["image"],
+      "required": [
+        "image"
+      ],
       "additionalProperties": false,
       "properties": {
         "image": {
@@ -202,7 +217,9 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["target"],
+            "required": [
+              "target"
+            ],
             "additionalProperties": false,
             "properties": {
               "target": {
@@ -231,10 +248,16 @@
             },
             "oneOf": [
               {
-                "required": ["target", "content"]
+                "required": [
+                  "target",
+                  "content"
+                ]
               },
               {
-                "required": ["target", "source"]
+                "required": [
+                  "target",
+                  "source"
+                ]
               }
             ]
           }
@@ -245,7 +268,10 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["source", "target"],
+            "required": [
+              "source",
+              "target"
+            ],
             "properties": {
               "source": {
                 "description": "The external volume reference.",
@@ -293,7 +319,9 @@
     },
     "containerProbe": {
       "type": "object",
-      "required": ["httpGet"],
+      "required": [
+        "httpGet"
+      ],
       "additionalProperties": false,
       "properties": {
         "httpGet": {
@@ -305,7 +333,10 @@
       "description": "An HTTP probe details.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["port", "path"],
+      "required": [
+        "port",
+        "path"
+      ],
       "properties": {
         "host": {
           "description": "Host name to connect to. Defaults to the workload IP. The is equivalent to a Host HTTP header.",
@@ -314,7 +345,10 @@
         "scheme": {
           "description": "Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.",
           "type": "string",
-          "enum": ["HTTP", "HTTPS"]
+          "enum": [
+            "HTTP",
+            "HTTPS"
+          ]
         },
         "path": {
           "description": "The path to access on the HTTP server.",

--- a/schemas/score-v1b1.json
+++ b/schemas/score-v1b1.json
@@ -4,28 +4,26 @@
   "title": "Score schema",
   "description": "Score workload specification",
   "type": "object",
-  "required": [
-    "apiVersion",
-    "metadata",
-    "containers"
-  ],
+  "required": ["apiVersion", "metadata", "containers"],
   "additionalProperties": false,
   "properties": {
     "apiVersion": {
       "description": "The declared Score Specification version.",
-      "type": "string"
+      "type": "string",
+      "pattern": "^score\\.dev/v1b1$"
     },
     "metadata": {
       "description": "The metadata description of the Workload.",
       "type": "object",
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": true,
       "properties": {
         "name": {
-          "description": "A string that can describe the Workload.",
-          "type": "string"
+          "description": "A string that can describe the Workload. This must be a valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-' but may not start or end with '-'.",
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 63,
+          "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
         }
       }
     },
@@ -35,9 +33,13 @@
       "additionalProperties": false,
       "properties": {
         "ports": {
-          "description": "List of network ports published by the service.",
+          "description": "The set of named network ports published by the service. The service name must be a valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-' but may not start or end with '-'.",
           "type": "object",
-          "minProperties": 1,
+          "propertyNames": {
+            "minLength": 2,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
+          },
           "additionalProperties": {
             "$ref": "#/$defs/servicePort"
           }
@@ -45,19 +47,28 @@
       }
     },
     "containers": {
-      "description": "The declared Score Specification version.",
+      "description": "The declared Score Specification version. The container name must be a valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-' but may not start or end with '-'.",
       "type": "object",
       "minProperties": 1,
       "additionalProperties": {
         "$ref": "#/$defs/container"
+      },
+      "propertyNames": {
+        "minLength": 2,
+        "maxLength": 63,
+        "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
       }
     },
     "resources": {
-      "description": "The dependencies needed by the Workload.",
+      "description": "The Resource dependencies needed by the Workload. The resource name must be a valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-' but may not start or end with '-'.",
       "type": "object",
-      "minProperties": 1,
       "additionalProperties": {
         "$ref": "#/$defs/resource"
+      },
+      "propertyNames": {
+        "minLength": 2,
+        "maxLength": 63,
+        "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
       }
     }
   },
@@ -65,111 +76,112 @@
     "servicePort": {
       "description": "The network port description.",
       "type": "object",
-      "required": [
-        "port"
-      ],
+      "required": ["port"],
       "additionalProperties": false,
       "properties": {
         "port": {
           "description": "The public service port.",
-          "type": "integer"
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
         },
         "protocol": {
           "description": "The transport level protocol. Defaults to TCP.",
-          "type": "string"
+          "type": "string",
+          "enum": ["TCP", "UDP"]
         },
         "targetPort": {
           "description": "The internal service port. This will default to 'port' if not provided.",
-          "type": "integer"
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
         }
       }
     },
     "resource": {
-      "description": "The resource name.",
+      "description": "The set of Resources associated with this Workload.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "properties": {
         "type": {
-          "description": "The resource in the target environment.",
-          "type": "string"
+          "description": "The Resource type. This should be a type supported by the Score implementations being used.",
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 63,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9-]{0,61}[A-Za-z0-9]$"
         },
         "class": {
-          "description": "A specialisation of the resource type.",
+          "description": "A specialisation of the Resource type.",
           "type": "string",
-          "pattern": "^[a-z0-9](?:-?[a-z0-9]+)+$"
+          "minLength": 2,
+          "maxLength": 63,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9-]{0,61}[A-Za-z0-9]$"
         },
         "metadata": {
-          "description": "The metadata for the resource.",
+          "description": "The metadata for the Resource.",
           "type": "object",
-          "minProperties": 1,
           "additionalProperties": true,
           "properties": {
             "annotations": {
-              "description": "Annotations that apply to the property.",
+              "description": "Annotations that apply to the Resource. The annotation can contain A-Z, a-z, 0-9, and '-' and may contain an optional /-separated RFC1123 Host Name prefix.",
               "type": "object",
-              "minProperties": 1,
               "additionalProperties": {
                 "type": "string"
+              },
+              "propertyNames": {
+                "minLength": 2,
+                "maxLength": 316,
+                "pattern": "^(([a-z0-9][a-z0-9-]{0,61}[a-z0-9])(\\.[a-z0-9][a-z0-9-]{0,61}[a-z0-9])*/)?[A-Za-z0-9][A-Za-z0-9._-]{0,61}[A-Za-z0-9]$"
               }
             }
           }
         },
-        "properties": {
-          "description": "DEPRECATED: The properties that can be referenced in other places in the Score Specification file.",
-          "type": [
-            "object",
-            "null"
-          ]
-        },
         "params": {
-          "description": "The parameters used to validate or provision the resource in the environment.",
-          "type": "object"
+          "description": "Optional parameters used to provision the Resource in the environment.",
+          "type": "object",
+          "additionalProperties": true
         }
       }
     },
     "resourcesLimits": {
-      "description": "The compute resources limits.",
+      "description": "The compute and memory resource limits.",
       "type": "object",
-      "minProperties": 1,
       "additionalProperties": false,
       "properties": {
         "memory": {
-          "description": "The memory limit.",
-          "type": "string"
+          "description": "The memory limit in bytes with optional unit specifier. For example 125M or 1Gi.",
+          "type": "string",
+          "pattern": "^[1-9]\\d*(K|M|G|T|Ki|Mi|Gi|Ti)?$"
         },
         "cpu": {
-          "description": "The CPU limit.",
-          "type": "string"
+          "description": "The CPU limit as whole or fractional CPUs. 'm' indicates milli-CPUs. For example 2 or 125m.",
+          "type": "string",
+          "pattern": "^\\d*(?:m|\\.\\d+)?$"
         }
       }
     },
     "container": {
-      "description": "The container name.",
+      "description": "The specification of a Container within the Workload.",
       "type": "object",
-      "required": [
-        "image"
-      ],
+      "required": ["image"],
       "additionalProperties": false,
       "properties": {
         "image": {
-          "description": "The image name and tag.",
-          "type": "string"
+          "description": "The container image name and tag.",
+          "type": "string",
+          "minLength": 1
         },
         "command": {
-          "description": "If specified, overrides container entry point.",
+          "description": "If specified, overrides the entrypoint defined in the container image.",
           "type": "array",
-          "minItems": 1,
           "items": {
             "type": "string"
           }
         },
         "args": {
-          "description": "If specified, overrides container entry point arguments.",
+          "description": "If specified, overrides the arguments passed to the container entrypoint.",
           "type": "array",
-          "minItems": 1,
           "items": {
             "type": "string"
           }
@@ -177,28 +189,31 @@
         "variables": {
           "description": "The environment variables for the container.",
           "type": "object",
-          "minProperties": 1,
+          "propertyNames": {
+            "minLength": 1,
+            "pattern": "^[^=]+$"
+          },
           "additionalProperties": {
             "type": "string"
           }
         },
         "files": {
-          "description": "The extra files to mount.",
+          "description": "The extra files to mount into the container.",
           "type": "array",
-          "minItems": 1,
           "items": {
             "type": "object",
-            "required": [
-              "target"
-            ],
+            "required": ["target"],
+            "additionalProperties": false,
             "properties": {
               "target": {
-                "description": "The file path and name.",
-                "type": "string"
+                "description": "The file path to expose in the container.",
+                "type": "string",
+                "minLength": 1
               },
               "mode": {
-                "description": "The file access mode.",
-                "type": "string"
+                "description": "The optional file access mode in octal encoding. For example 0600.",
+                "type": "string",
+                "pattern": "^0?[0-7]{3}$"
               },
               "source": {
                 "description": "The relative or absolute path to the content file.",
@@ -207,19 +222,7 @@
               },
               "content": {
                 "description": "The inline content for the file.",
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "deprecated": true,
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                ]
+                "type": "string"
               },
               "noExpand": {
                 "description": "If set to true, the placeholders expansion will not occur in the contents of the file.",
@@ -228,14 +231,10 @@
             },
             "oneOf": [
               {
-                "required": [
-                  "content"
-                ]
+                "required": ["target", "content"]
               },
               {
-                "required": [
-                  "source"
-                ]
+                "required": ["target", "source"]
               }
             ]
           }
@@ -243,13 +242,10 @@
         "volumes": {
           "description": "The volumes to mount.",
           "type": "array",
-          "minItems": 1,
           "items": {
             "type": "object",
-            "required": [
-              "source",
-              "target"
-            ],
+            "additionalProperties": false,
+            "required": ["source", "target"],
             "properties": {
               "source": {
                 "description": "The external volume reference.",
@@ -263,7 +259,7 @@
                 "description": "The target mount on the container.",
                 "type": "string"
               },
-              "read_only": {
+              "readOnly": {
                 "description": "Indicates if the volume should be mounted in a read-only mode.",
                 "type": "boolean"
               }
@@ -273,7 +269,6 @@
         "resources": {
           "description": "The compute resources for the container.",
           "type": "object",
-          "minProperties": 1,
           "additionalProperties": false,
           "properties": {
             "limits": {
@@ -298,7 +293,7 @@
     },
     "containerProbe": {
       "type": "object",
-      "minProperties": 1,
+      "required": ["httpGet"],
       "additionalProperties": false,
       "properties": {
         "httpGet": {
@@ -310,41 +305,38 @@
       "description": "An HTTP probe details.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "path"
-      ],
+      "required": ["port", "path"],
       "properties": {
         "host": {
-          "description": "Host name to connect to. Defaults to the container IP.",
+          "description": "Host name to connect to. Defaults to the workload IP. The is equivalent to a Host HTTP header.",
           "type": "string"
         },
         "scheme": {
           "description": "Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.",
           "type": "string",
-          "enum": [
-            "HTTP",
-            "HTTPS"
-          ]
+          "enum": ["HTTP", "HTTPS"]
         },
         "path": {
-          "description": "The path of the HTTP probe endpoint.",
+          "description": "The path to access on the HTTP server.",
           "type": "string"
         },
         "port": {
-          "description": "The path of the HTTP probe endpoint.",
-          "type": "integer"
+          "description": "The port to access on the workload.",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
         },
         "httpHeaders": {
           "description": "Additional HTTP headers to send with the request",
           "type": "array",
-          "minItems": 1,
           "items": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
               "name": {
                 "description": "The HTTP header name.",
-                "type": "string"
+                "type": "string",
+                "pattern": "^[A-Za-z0-9_-]+$"
               },
               "value": {
                 "description": "The HTTP header value.",


### PR DESCRIPTION
This PR updates the score specification embedded in these docs and updates the reference docs to fix some missing details and incorrect names (primarily volume read_only).

This was done via a `subptree pull` as documented in the score-spec/schema repo (which is why the makefil and sample were pulled in).

🚀 