### PR TITLE
Add custom alias template to fix redirects

### DIFF
--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,0 +1,11 @@
+<!-- Customized alias template to ensure relative links. See https://gohugo.io/content-management/urls/#Aliases -->
+<!DOCTYPE html>
+<html lang="{{ site.Language.LanguageCode }}">
+  <head>
+    <title>{{ .RelPermalink }}</title>
+    <link rel="canonical" href="{{ .RelPermalink }}">
+    <meta name="robots" content="noindex">
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url={{ .RelPermalink }}">
+  </head>
+</html>

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,4 +1,4 @@
-<!-- Customized alias template to ensure relative links. See https://gohugo.io/content-management/urls/#Aliases -->
+<!-- Customized alias template to ensure relative links. See https://gohugo.io/content-management/urls/#aliases -->
 <!DOCTYPE html>
 <html lang="{{ site.Language.LanguageCode }}">
   <head>


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The recent page restructurings introduced page redirects to continue serving the pre-existing URLs. Those redirects, implemented as Hugo `alias` entries, do not work properly and consistently link to a `http://localhost...` address.

## What does this change do?

The change introduces a custom alias template as per the [official documentation](https://gohugo.io/content-management/urls/#aliases). It makes sure that the relative link is used at all times for redirects.

## What is your testing strategy?

I inspected the `index.html` files that Hugo [generates](https://gohugo.io/content-management/urls/#how-aliases-work) for each redirect location. Where previously the redirect target was an absolute URL `http://localhost:1313/some/page...`, it is now a   relative URL `/some/page`.

## Have you read the [Contributing Guidelines](CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](CONTRIBUTING.md)
