### PR TITLE
Bump Hugo version

### DIFF
--- a/Dockerfile-publish
+++ b/Dockerfile-publish
@@ -1,10 +1,7 @@
-FROM klakegg/hugo:0.101.0-ext-alpine as docsy
+FROM hugomods/hugo:exts-0.123.8 as docsy
 
-RUN apk update
-RUN apk add git
-COPY . /app/
-WORKDIR /app/
+COPY . /src
+WORKDIR /src
 RUN npm install --production=false
-RUN git config --global --add safe.directory /app/
 
-CMD ["serve", "--cleanDestinationDir", "--themesDir", "../..", "--disableFastRender", "--ignoreCache", "--watch"]
+CMD [ "hugo", "server", "--themesDir", "../..", "--disableFastRender", "--renderToMemory", "--bind", "0.0.0.0" ]

--- a/config.toml
+++ b/config.toml
@@ -62,11 +62,11 @@ id = "UA-00000000-0"
 [languages]
 [languages.en]
 title = "Score"
-description = "Score is platform-agnostic specification for defining environment configuration for cloud based workloads"
 languageName = "English"
 # Weight used for sorting.
 weight = 1
-
+[languages.en.params]
+description = "Score is platform-agnostic specification for defining environment configuration for cloud based workloads"
 
 [markup]
 [markup.goldmark]

--- a/package.json
+++ b/package.json
@@ -24,10 +24,7 @@
   "description": "Score technical documentation.",
   "devDependencies": {
     "autoprefixer": "^10.4.0",
-    "hugo-extended": "^0.103.1",
-    "lunr": "^2.3.9",
-    "postcss": "^8.4.16",
-    "postcss-cli": "^10.0.0"
+    "lunr": "^2.3.9"
   },
   "homepage": "https://github.com/score-spec/docs#readme",
   "license": "Apache-2.0",


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The Hugo version `0.101.0` currently in use is outdated. Local testing using a current version does not generate predictable results or leads to misconfigurations due to changed config requirements between the version, e.g. [this change](
https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120).

## What does this change do?

This PR uses a current community-maintained Hugo base image in version `0.123.8`. The previously used image is not updated any longer.
The change also removes unnecessary dependencies which are now covered by the base image.

## What is your testing strategy?

I tested the new code in two ways:
- Running the local Hugo server directly using the `hugo server` command
- Building and running the image locally using Docker

## Have you read the [Contributing Guidelines](CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](CONTRIBUTING.md)
