### PR TITLE
Consolidate duplicate overview pages

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,27 +1,5 @@
-+++
-title = "Score overview"
-linkTitle = "Score"
-abstract = "Score is an open-source Workload Specification and CLI conversion tool used to eliminate configuration management between local and remote environments."
-+++
-
-_Score_ provides a developer-centric and platform-agnostic Workload specification to improve developer productivity and experience. Score eliminates configuration management between local and remote environments.
-
-## Develop your Score Spec
-
-To compose a Score Specification file, you'll do the following:
-
-- Scope: identify containers, resources, and services needed for your infrastructure.
-- Compose: compose your resources into the Score Specification file.
-- Transform: transform your Score Specification file to the Platform of your choice.
-
-## Getting started
-
-To get started, you'll want to:
-
-- Read through the [Overview page]({{< relref "/overview" >}} "Overview").
-- Learn how to [install the score-compose reference implementation (CLI)]({{< relref "docs/score-implementation/score-compose#installation" >}} "Learn to install").
-
-Beyond the getting started section, you can learn more about Score and how to implement it into your own workflows.
-
-- [Concepts](/docs/concepts): Recommended reading for anyone consuming or operating Score.
-- [Set environment variables](/docs/how-to-guides/enviornment-variables) Learn how to set and manage environment-specific variables.
+---
+title: "Score overview"
+linkTitle: "Score"
+abstract: "Score is an open-source Workload Specification and CLI conversion tool used to eliminate configuration management between local and remote environments."
+---

--- a/content/en/docs/overview/_index.md
+++ b/content/en/docs/overview/_index.md
@@ -4,7 +4,9 @@ linkTitle: "Overview"
 weight: 1
 Victor_Hugo: "true"
 Focus_Keyword: "Learn about the Score Specification"
+url: /docs
 aliases:
+- /docs/overview
 - /docs/concepts
 - /docs/concepts/container
 - /docs/concepts/environment-configuration


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

There are currently two overlapping pages: the landing page at `/docs`, titled "Score overview", and an "Overview" page at `/docs/overview`. Their content is redundant and the purpose of each not clearly delineated.

## What does this change do?

This PR removes the content of the former landing page and puts the newly renovated "Overview" page in its place, which is now served at the core URL `/docs`. The URL `/docs/overview` still redirects here.

## What is your testing strategy?

I built and ran the image locally and tested all URL redirects.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
