### PR TITLE
Fix links in score-helm callout

### DIFF
--- a/content/en/docs/score implementation/Other/score-helm.md
+++ b/content/en/docs/score implementation/Other/score-helm.md
@@ -8,7 +8,7 @@ aliases:
 - /docs/reference/score-cli/score-helm/
 ---
 
-{{< alert context="info" >}} Deprecation Notice: We have deprecated the score-helm CLI implementation. To get started with Score, we recommend using one of our reference implementations [score-compose](../score-compose.md) or [score-k8s](../score-k8s.md). If you're interested in developing a score-helm reference implementation, we'd love to support you! Please [reach out](https://github.com/score-spec/spec?tab=readme-ov-file#-get-in-touch) to us for assistance and collaboration. {{< /alert >}}
+{{< alert context="info" >}} Deprecation Notice: We have deprecated the score-helm CLI implementation. To get started with Score, we recommend using one of our reference implementations [score-compose]({{< relref "/docs/score implementation/score-compose" >}}) or [score-k8s]({{< relref "/docs/score implementation/score-k8s" >}}). If you're interested in developing a score-helm reference implementation, we'd love to support you! Please [reach out](https://github.com/score-spec/spec?tab=readme-ov-file#-get-in-touch) to us for assistance and collaboration. {{< /alert >}}
 
 # Overview
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The links on the newly added callout on `score-helm` deprecation are broken on the rendered site.

## What does this change do?

The change replaces markdown links with the Hugo style `relref` format.

## What is your testing strategy?

I started the Hugo test server locally and checked the result in the rendered site.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](CONTRIBUTING.md)
