### PR TITLE
fix: update Score slack links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -191,7 +191,7 @@ icon = "fab fa-github"
 desc = "Development takes place here!"
 [[params.links.developer]]
 name = "Slack"
-url = "https://join.slack.com/t/scorecommunity/shared_invite/zt-1i2glkqkl-EnjSWSCgYUyaEGwmDYBZZQ"
+url = "https://cloud-native.slack.com/archives/C07DN0D1UCW"
 icon = "fab fa-slack"
 desc = "Chat with other project developers"
 [[params.links.developer]]

--- a/content/en/docs/get started/_index.md
+++ b/content/en/docs/get started/_index.md
@@ -82,4 +82,4 @@ Congrats! You’ve successfully run your first Score Implementation with a Hello
 
 - **Explore other implementations**: Play around with [other available open-source Score implementations](/docs/score-implementation/). For example, you could continue by running the same Score file used in the example above via the score-k8s CLI to generate a Kubernetes manifest.
 
-- **Join the Score community Slack**: If you encounter any issues or have questions, feel free to reach out to us in the [Score community Slack](https://join.slack.com/t/scorecommunity/shared_invite/zt-2a0x563j7-i1vZOK2Yg2o4TwCM1irIuA).
+- **Join the Score community Slack**: If you encounter any issues or have questions, feel free to reach out to us in the [Score](https://cloud-native.slack.com/archives/C07DN0D1UCW) channel on the CNCF Slack (<https://slack.cncf.io/>).

--- a/content/en/docs/score implementation/Other/score-helm.md
+++ b/content/en/docs/score implementation/Other/score-helm.md
@@ -170,4 +170,4 @@ score-helm run -f ./score.yaml -o ./values.yaml --verbose
 
 Explore examples for score-helm in the [examples library](https://github.com/score-spec/score-helm/tree/main/examples) on GitHub.
 
-If you encounter any issues or have questions, feel free to reach out to us in the [Score community Slack](https://join.slack.com/t/scorecommunity/shared_invite/zt-2a0x563j7-i1vZOK2Yg2o4TwCM1irIuA).
+If you encounter any issues or have questions, feel free to reach out to us in the [Score](https://cloud-native.slack.com/archives/C07DN0D1UCW) channel on the CNCF Slack (<https://slack.cncf.io/>).

--- a/content/en/docs/score implementation/score-compose.md
+++ b/content/en/docs/score implementation/score-compose.md
@@ -340,4 +340,4 @@ score-compose --version
 
 Explore a variety of examples for score-compose, ranging from simple "hello world" setups to more complex configurations, including resource provisioning and multiple workloads. You can find these examples in our [examples library](https://github.com/score-spec/score-compose/tree/main/examples).
 
-If you encounter any issues or have questions, feel free to reach out to us in the [Score community Slack](https://join.slack.com/t/scorecommunity/shared_invite/zt-2a0x563j7-i1vZOK2Yg2o4TwCM1irIuA).
+If you encounter any issues or have questions, feel free to reach out to us in the the [Score](https://cloud-native.slack.com/archives/C07DN0D1UCW) channel on the CNCF Slack (<https://slack.cncf.io/>).


### PR DESCRIPTION
Same process as https://github.com/score-spec/spec/pull/99. Add the link to the channel as well as the invite process.