### PR TITLE
Update schema url reference to new score-spec/spec repo

### DIFF
--- a/content/en/docs/score specification/ide-linter-autocomplete.md
+++ b/content/en/docs/score specification/ide-linter-autocomplete.md
@@ -24,7 +24,7 @@ For instance, configuring Visual Studio Code (VSC) involves the following steps:
 
 ```json
 "yaml.schemas": {
-       "https://raw.githubusercontent.com/score-spec/schema/main/score-v1b1.json": "score.yaml"
+       "https://raw.githubusercontent.com/score-spec/spec/main/score-v1b1.json": "score.yaml"
    }
 ```
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Fix broken link in score web.

## What does this change do?
change  reference from https://raw.githubusercontent.com/score-spec/schema/main/score-v1b1.json to the new          https://raw.githubusercontent.com/score-spec/spec/main/score-v1b1.json

## What is your testing strategy?
No needed

## Is this related to any issues?
No

## Have you read the [Contributing Guidelines](CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](CONTRIBUTING.md)
