### PR TITLE
Fix broken link to score spec schema

### DIFF
--- a/content/en/docs/score specification/score-spec-reference.md
+++ b/content/en/docs/score specification/score-spec-reference.md
@@ -34,7 +34,7 @@ metadata:
     annotations-name: string # optional
 ```
 
-`apiVersion`: the declared Score Specification version. Find the current version [here](https://github.com/score-spec/schema/blob/main/score-v1b1.json).
+`apiVersion`: the declared Score Specification version. Find the current version [here](https://github.com/score-spec/spec/blob/main/score-v1b1.json).
 
 `metadata`: the metadata description of your workload.
 


### PR DESCRIPTION
Per the README.md in https://github.com/score-spec/schema, the location of the schema has moved to https://github.com/score-spec/spec.

Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Fix the broken link to make the docs more accurate.

## What does this change do?

Updates the broken link to the score-v1b1.json schema specification to the new location.

## What is your testing strategy?

Manual testing of docs in my fork.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
