### PR TITLE
Fix ide-linter-autocomplete with new spec location

### DIFF
--- a/content/en/docs/score specification/ide-linter-autocomplete.md
+++ b/content/en/docs/score specification/ide-linter-autocomplete.md
@@ -24,7 +24,7 @@ For instance, configuring Visual Studio Code (VSC) involves the following steps:
 
 ```json
 "yaml.schemas": {
-       "https://raw.githubusercontent.com/score-spec/schema/main/score-v1b1.json": "score.yaml"
+       "https://raw.githubusercontent.com/score-spec/spec/main/score-v1b1.json": "score.yaml"
    }
 ```
 


### PR DESCRIPTION
https://raw.githubusercontent.com/score-spec/schema/main/score-v1b1.json is giving a 404, since the previous location has been archived: https://github.com/score-spec/schema/pull/22.

In VS Code it was giving this error:
```
Unable to load schema from 'https://raw.githubusercontent.com/score-spec/schema/main/score-v1b1.json': Request vscode/content failed unexpectedly without providing any details.
```

## Have you read the [Contributing Guidelines](CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](CONTRIBUTING.md)
