### PR TITLE
Update resources-provisioners.md for `score-k8s`: `service-port` and `mssql`

### DIFF
--- a/content/en/docs/score implementation/score-k8s/resources-provisioners.md
+++ b/content/en/docs/score implementation/score-k8s/resources-provisioners.md
@@ -11,16 +11,18 @@ aliases:
 
 `score-k8s` comes with out-of-the-box support for:
 
-| Type       | Class     | Params                 | Output                                                          |
-| ---------- | --------- | ---------------------- | --------------------------------------------------------------- |
-| `ampq`     | `default` | (none)                 | `host`, `port`, `username`, `password`, `vhost`                 |
-| `dns`      | `default` | (none)                 | `host`                                                          |
-| `mongodb`  | `default` | (none)                 | `host`, `port`, `username`, `password`, `name`, `connection`    |
-| `mysql`    | `default` | (none)                 | `host`, `port`, `name` (aka `database`), `username`, `password` |
-| `postgres` | `default` | (none)                 | `host`, `port`, `name` (aka `database`), `username`, `password` |
-| `redis`    | `default` | (none)                 | `host`, `port`, `username`, `password`                          |
-| `route`    | `default` | `host`, `path`, `port` |                                                                 |
-| `volume`   | `default` | (none)                 | `source`                                                        |
+| Type           | Class     | Params                 | Output                                                             |
+| -------------- | --------- | ---------------------- | ------------------------------------------------------------------ |
+| `ampq`         | `default` | (none)                 | `host`, `port`, `username`, `password`, `vhost`                    |
+| `dns`          | `default` | (none)                 | `host`                                                             |
+| `mongodb`      | `default` | (none)                 | `host`, `port`, `username`, `password`, `name`, `connection`       |
+| `mssql`        | `default` | (none)                 | `server`, `port`, `username`, `password`, `database`, `connection` |
+| `mysql`        | `default` | (none)                 | `host`, `port`, `name` (aka `database`), `username`, `password`    |
+| `postgres`     | `default` | (none)                 | `host`, `port`, `name` (aka `database`), `username`, `password`    |
+| `redis`        | `default` | (none)                 | `host`, `port`, `username`, `password`                             |
+| `route`        | `default` | `host`, `path`, `port` |                                                                    |
+| `service-port` | `default` | `workload`, `port`     | `hostname`, `port`                                                 |
+| `volume`       | `default` | (none)                 | `source`                                                           |
 
 These can be found in the default provisioners file. You are encouraged to write your own provisioners and add them to the `.score-k8s` directory (with the `.provisioners.yaml` extension) or contribute them upstream to the [default.provisioners.yaml](https://github.com/score-spec/score-k8s/blob/main/internal/provisioners/default/zz-default.provisioners.yaml) file.
 


### PR DESCRIPTION
Update resources-provisioners.md for `score-k8s`: `service-port` (https://github.com/score-spec/score-k8s/pull/70) and `mssql` (https://github.com/score-spec/score-k8s/pull/73).