### PR TITLE
chore: update cli documentation for score-compore resources list

### DIFF
--- a/content/en/docs/score implementation/score-compose/cli.md
+++ b/content/en/docs/score implementation/score-compose/cli.md
@@ -256,6 +256,16 @@ Lists the unique identifiers (UIDs) of all provisioned resources.
 score-compose resources list
 ```
 
+##### Flags
+
+###### --format | -f
+
+Display listed resources in the format provided. Uses `table` as default value. Allowed values: `table`, `json`
+
+```bash
+score-compose resources list --fornat json
+```
+
 ### Flags
 
 #### `--help` | `-h`

--- a/content/en/docs/score implementation/score-compose/resources-provisioners.md
+++ b/content/en/docs/score implementation/score-compose/resources-provisioners.md
@@ -27,7 +27,7 @@ aliases:
 | `service-port`  | (any) | `workload`, `port`     | `hostname`, `port`                                                                                                                                              |
 | `s3`            | (any) | (none)                 | `endpoint`, `access_key_id`, `secret_key`, `bucket`, with `region=""`, `aws_access_key_id=<access_key_id>`, and `aws_secret_key=<secret_key>` for compatibility |
 | `volume`        | (any) | (none)                 | `source`                                                                                                                                                        |
-| mssql           | (any) | (none)                 | `server`, `port`, `connection`, `database`, `username`, `password`                                                                                              |
+| `mssql`         | (any) | (none)                 | `server`, `port`, `connection`, `database`, `username`, `password`                                                                                              |
 
 These can be found in the default provisioners file. You are encouraged to write your own provisioners and add them to the `.score-compose` directory (with the `.provisioners.yaml` extension) or contribute them upstream to the [default.provisioners.yaml](https://github.com/score-spec/score-compose/blob/main/internal/command/default.provisioners.yaml) file.
 


### PR DESCRIPTION


Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

New flag has been added in score-compose resources list 

## What does this change do?

Update cli documentation for score-compore resources list  with new output format flag

can be merged after score-spec/score-compose#267

## What is your testing strategy?

Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
