### PR TITLE
Use bulleted list for resources

### DIFF
--- a/content/en/docs/score specification/score-spec-reference.md
+++ b/content/en/docs/score specification/score-spec-reference.md
@@ -287,17 +287,13 @@ resources: # optional
       param-name: value
 ```
 
-`resources`: the resource dependencies needed by the workload.
-
-`resource-name`: a required property that specifies the resource name.
-
-`type`: the resource type. This should be a type supported by the Score implementations being used.
-`class`: an optional specialisation of the resource type.
-`id`: an optional external resource identifier. When two resources share the same type, class, and id, they are considered the same resource when used across related Workloads.
-`params`: an optional map of parameters that may configure this resource. Params support both metadata and resource placeholders local to this Workload.
-
-`metadata`: an optional property that specifies additional resource metadata.
-
+- `resources`: the resource dependencies needed by the workload.
+- `resource-name`: a required property that specifies the resource name.
+- `type`: the resource type. This should be a type supported by the Score implementations being used.
+- `class`: an optional specialisation of the resource type.
+- `id`: an optional external resource identifier. When two resources share the same type, class, and id, they are considered the same resource when used across related Workloads.
+- `params`: an optional map of parameters that may configure this resource. Params support both metadata and resource placeholders local to this Workload.
+- `metadata`: an optional property that specifies additional resource metadata.
 - `annotations`: An optional property to specify meta data for a resource. This can be utilised to provide additional instructions for the Score CLI Implementation to interpret.
 
 ### Resource example


### PR DESCRIPTION
## What is the motivation?

The docs where hard to read when `type`, `class`, `id`, `params` where on one line.  Other areas and `annotations` use bullet points so standardize to that.

## What does this change do?

Fix markdown with missing bullet points, so it doesn't run the field descriptions across one line when rendered.

## What is your testing strategy?

Trivial change to docs, didn't test aside from reviewing code.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
