### PR TITLE
Add DevContainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+	"name": "Score's docs Dev Container",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:20",
+	"features": {
+		"ghcr.io/devcontainers/features/go:1": {
+				"version": "latest"
+		},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"moby": true,
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+			"version": "latest",
+			"helm": "latest",
+			"minikube": "latest"
+		}
+	},
+	"postCreateCommand": "bash .devcontainer/installMoreTools.sh",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"redhat.vscode-yaml"
+			],
+			"settings": {
+				"yaml.schemas": {
+					"https://raw.githubusercontent.com/score-spec/spec/main/score-v1b1.json": "score.yaml"
+				}
+			}
+		}
+	}
+}

--- a/.devcontainer/installMoreTools.sh
+++ b/.devcontainer/installMoreTools.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+mkdir install-more-tools
+cd install-more-tools
+
+SCORE_COMPOSE_VERSION=$(curl -sL https://api.github.com/repos/score-spec/score-compose/releases/latest | jq -r .tag_name)
+wget https://github.com/score-spec/score-compose/releases/download/${SCORE_COMPOSE_VERSION}/score-compose_${SCORE_COMPOSE_VERSION}_linux_amd64.tar.gz
+tar -xvf score-compose_${SCORE_COMPOSE_VERSION}_linux_amd64.tar.gz
+chmod +x score-compose
+sudo mv score-compose /usr/local/bin
+
+SCORE_K8S_VERSION=$(curl -sL https://api.github.com/repos/score-spec/score-k8s/releases/latest | jq -r .tag_name)
+wget https://github.com/score-spec/score-k8s/releases/download/${SCORE_K8S_VERSION}/score-k8s_${SCORE_K8S_VERSION}_linux_amd64.tar.gz
+tar -xvf score-k8s_${SCORE_K8S_VERSION}_linux_amd64.tar.gz
+chmod +x score-k8s
+sudo mv score-k8s /usr/local/bin
+
+KIND_VERSION=$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r .tag_name)
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64
+chmod +x ./kind
+sudo mv ./kind /usr/local/bin/kind
+
+cd ..
+rm -rf install-more-tools


### PR DESCRIPTION
Add DevContainer

To simplify and accelerate contributions, let's have a DevContainer showing the tools and versions needed.

For example, currently, opening this repo in Codespace, will land to this error with `yarn install`:
```none
yarn install v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
error hugo-cli@0.14.0: The engine "node" is incompatible with this module. Expected version ">= 20". Got "16.20.2"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
Which is not good, that's because the default Node version is `v16.20.2`.

This PR adds the DevContainer with the required tools:
- Node 20
- Go
With that someone can just come and run this right away, and easily test and contribute:
```bash
yarn install
yarn run hugo server
```
Not mandatory, but we are also adding in this DevContaine these tools:
- Docker
- Kind
- `score-compose`
- `score-k8s`