### PR TITLE
Fix CSS for code in links

### DIFF
--- a/assets/scss/components/_code.scss
+++ b/assets/scss/components/_code.scss
@@ -11,6 +11,10 @@ code {
   background: $bg-light;
   color: $black;
   padding: 0.25rem 0.5rem;
+
+  a > & {
+    background: none;
+  }
 }
 
 pre {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Text rendered as code is currently not legible when it is part of a link, e.g. on the [Community](https://docs.score.dev/docs/community/) page:

![image](https://github.com/user-attachments/assets/c29a47fe-2ce9-4b61-9380-6dd8c02fe33b)

## What does this change do?

The PR introduces a CSS addition that nullifies the `background` for a `a > code` situation, causing the text to be visible. Local preview:

![image](https://github.com/user-attachments/assets/5f690e7d-18a7-4a0d-aefa-2d06f7f4913f)

## What is your testing strategy?

I built the site locally and started the Hugo test server. Tested in Chrome and Firefox.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](CONTRIBUTING.md)
