### PR TITLE
docs: add LLM Models example entry

### DIFF
--- a/content/en/docs/examples/included/llm-models-dmr.md
+++ b/content/en/docs/examples/included/llm-models-dmr.md
@@ -1,0 +1,107 @@
+---
+title: "LLM Models with Docker Model Runner"
+description: "How to deploy local LLM models with Open WebUI and Docker Model Runner using `score-compose`"
+headless: true
+toc_hide: true
+---
+
+To begin, follow the [installation instructions](/docs/score-implementation/score-compose/installation) to install the latest version of `score-compose`.
+
+{{% alert title="Prerequisites" %}}
+Docker Model Runner (DMR) requires [Docker Desktop](https://www.docker.com/products/docker-desktop/) with the **Model Runner** feature enabled. You can enable it from Docker Desktop Settings under the **Features in Development** or **Beta Features** section.
+{{% /alert %}}
+
+## `init`
+
+Initialize your current `score-compose` workspace with the Docker Model Runner provisioner. Run the following command in your terminal:
+
+```bash
+score-compose init --no-sample \
+    --provisioners https://raw.githubusercontent.com/score-spec/community-provisioners/refs/heads/main/llm-model/score-compose/10-dmr-llm-model.provisioners.yaml
+```
+
+The `init` command will create the `.score-compose` directory with the [default resource provisioners]({{< relref "/docs/score-implementation/score-compose/resources-provisioners/" >}}) available, plus the Docker Model Runner-specific provisioner for the `llm-model` resource type.
+
+You can see the resource provisioners available by running this command:
+
+```bash
+score-compose provisioners list
+```
+
+The Score file example illustrated uses two resource types: `llm-model` and `volume`.
+
+```none
++---------------+-------+--------+--------------------+---------------------------------+
+|     TYPE      | CLASS | PARAMS |      OUTPUTS       |          DESCRIPTION            |
++---------------+-------+--------+--------------------+---------------------------------+
+| llm-model     | (any) | model  | url                | Provisions an LLM model via     |
+|               |       |        |                    | Docker Model Runner             |
++---------------+-------+--------+--------------------+---------------------------------+
+| volume        | (any) |        | source, type       | Creates a persistent volume     |
+|               |       |        |                    | that can be mounted on a        |
+|               |       |        |                    | workload.                       |
++---------------+-------+--------+--------------------+---------------------------------+
+```
+
+## `generate`
+
+Convert the `score.yaml` file into a deployable `compose.yaml`. Run the following command in your terminal:
+
+```bash
+score-compose generate score.yaml \
+    --image ghcr.io/open-webui/open-webui:main-slim \
+    --publish 8080:open-webui:8080 \
+    --override-property containers.open-webui.variables.WEBUI_NAME="Hello, DMR with Score Compose!" \
+    --output compose.yaml
+```
+
+The `generate` command will add the input `score.yaml` workload with a particular container image to the `.score-compose/state.yaml` state file and generate the output `compose.yaml`.
+
+The `--publish` flag exposes the Open WebUI port to the host so you can access it in your browser.
+
+See the generated `compose.yaml` by running this command:
+
+```bash
+cat compose.yaml
+```
+
+If you make any modifications to the `score.yaml` file, run `score-compose generate score.yaml` to regenerate the output `compose.yaml`.
+
+## `docker compose`
+
+Run `docker compose up` to execute the generated `compose.yaml` file:
+
+```bash
+docker compose up -d --wait
+```
+
+This will pull the requested LLM models (`ai/gemma3:270M-UD-IQ2_XXS` and `ai/smollm2:135M-Q2_K`) via Docker Model Runner, and then start the Open WebUI container connected to the DMR backend.
+
+## Verify
+
+Check the Docker images, including the LLM model images pulled by Docker Model Runner:
+
+```bash
+docker images
+```
+
+```none
+REPOSITORY             TAG                  SIZE
+open-webui             main-slim            ...
+ai/gemma3              270M-UD-IQ2_XXS      182MB
+ai/smollm2             135M-Q2_K            56.9MB
+```
+
+See the running containers:
+
+```bash
+docker ps
+```
+
+You should see the `open-webui` container running and connected to the Docker Model Runner backend.
+
+## Access Open WebUI
+
+Open your browser and navigate to [http://localhost:8080](http://localhost:8080) to access the Open WebUI frontend. You can now chat with the LLM models you deployed!
+
+Congrats! You've successfully deployed, with the `score-compose` implementation, local LLM models with Open WebUI and Docker Model Runner. You provisioned them through Docker, without writing the Docker Compose file by yourself.

--- a/content/en/docs/examples/included/llm-models-dmr.md
+++ b/content/en/docs/examples/included/llm-models-dmr.md
@@ -8,7 +8,7 @@ toc_hide: true
 To begin, follow the [installation instructions](/docs/score-implementation/score-compose/installation) to install the latest version of `score-compose`.
 
 {{% alert title="Prerequisites" %}}
-Docker Model Runner (DMR) requires [Docker Desktop](https://www.docker.com/products/docker-desktop/) with the **Model Runner** feature enabled. You can enable it from Docker Desktop Settings under the **Features in Development** or **Beta Features** section.
+Docker Model Runner (DMR) needs to be set up in your local environment. Follow the [DMR get started guide](https://docs.docker.com/model-runner/get-started/) to set it up.
 {{% /alert %}}
 
 ## `init`

--- a/content/en/docs/examples/included/llm-models-ollama.md
+++ b/content/en/docs/examples/included/llm-models-ollama.md
@@ -1,0 +1,116 @@
+---
+title: "LLM Models with Ollama"
+description: "How to deploy local LLM models with Open WebUI and Ollama using `score-compose`"
+headless: true
+toc_hide: true
+---
+
+To begin, follow the [installation instructions](/docs/score-implementation/score-compose/installation) to install the latest version of `score-compose`.
+
+## `init`
+
+Initialize your current `score-compose` workspace with the Ollama provisioner and patch template. Run the following command in your terminal:
+
+```bash
+score-compose init --no-sample \
+    --patch-templates https://raw.githubusercontent.com/score-spec/community-patchers/refs/heads/main/score-compose/ollama.tpl \
+    --provisioners https://raw.githubusercontent.com/score-spec/community-provisioners/refs/heads/main/llm-model/score-compose/10-ollama-llm-model-service.provisioners.yaml
+```
+
+The `init` command will create the `.score-compose` directory with the [default resource provisioners]({{< relref "/docs/score-implementation/score-compose/resources-provisioners/" >}}) available, plus the Ollama-specific provisioner for the `llm-model` resource type.
+
+The `--patch-templates` option adds the [`ollama.tpl`](https://github.com/score-spec/community-patchers/blob/main/score-compose/ollama.tpl) patcher which configures the Ollama service integration in the generated Docker Compose file.
+
+You can see the resource provisioners available by running this command:
+
+```bash
+score-compose provisioners list
+```
+
+The Score file example illustrated uses two resource types: `llm-model` and `volume`.
+
+```none
++---------------+-------+--------+--------------------+---------------------------------+
+|     TYPE      | CLASS | PARAMS |      OUTPUTS       |          DESCRIPTION            |
++---------------+-------+--------+--------------------+---------------------------------+
+| llm-model     | (any) | model  | url                | Provisions an LLM model via     |
+|               |       |        |                    | Ollama                          |
++---------------+-------+--------+--------------------+---------------------------------+
+| volume        | (any) |        | source, type       | Creates a persistent volume     |
+|               |       |        |                    | that can be mounted on a        |
+|               |       |        |                    | workload.                       |
++---------------+-------+--------+--------------------+---------------------------------+
+```
+
+## `generate`
+
+Convert the `score.yaml` file into a deployable `compose.yaml`. Run the following command in your terminal:
+
+```bash
+score-compose generate score.yaml \
+    --image ghcr.io/open-webui/open-webui:main-slim \
+    --publish 8080:open-webui:8080 \
+    --override-property containers.open-webui.variables.WEBUI_NAME="Hello, Ollama with Score Compose!" \
+    --output compose.yaml
+```
+
+The `generate` command will add the input `score.yaml` workload with a particular container image to the `.score-compose/state.yaml` state file and generate the output `compose.yaml`.
+
+The `--publish` flag exposes the Open WebUI port to the host so you can access it in your browser.
+
+See the generated `compose.yaml` by running this command:
+
+```bash
+cat compose.yaml
+```
+
+If you make any modifications to the `score.yaml` file, run `score-compose generate score.yaml` to regenerate the output `compose.yaml`.
+
+## `docker compose`
+
+Run `docker compose up` to execute the generated `compose.yaml` file:
+
+```bash
+docker compose up -d --wait
+```
+
+This will pull the Ollama container image, start the Ollama service, pull the requested LLM models (`gemma3:270m` and `smollm2:135m`), and then start the Open WebUI container connected to the Ollama backend.
+
+## Verify
+
+Check the Docker images that were pulled:
+
+```bash
+docker images
+```
+
+```none
+REPOSITORY               TAG            SIZE
+ollama/ollama            latest         3.33GB
+open-webui               main-slim      ...
+```
+
+Check that the LLM models were successfully pulled by Ollama:
+
+```bash
+curl localhost:11434/api/tags | jq -r .models[].name
+```
+
+```none
+gemma3:270m
+smollm2:135m
+```
+
+See the running containers:
+
+```bash
+docker ps
+```
+
+You should see the `open-webui` and `ollama` containers running, along with some exited "puller" containers that were used to download the models.
+
+## Access Open WebUI
+
+Open your browser and navigate to [http://localhost:8080](http://localhost:8080) to access the Open WebUI frontend. You can now chat with the LLM models you deployed!
+
+Congrats! You've successfully deployed, with the `score-compose` implementation, local LLM models with Open WebUI and Ollama. You provisioned them through Docker, without writing the Docker Compose file by yourself.

--- a/content/en/docs/examples/included/llm-models-ollama.md
+++ b/content/en/docs/examples/included/llm-models-ollama.md
@@ -19,7 +19,7 @@ score-compose init --no-sample \
 
 The `init` command will create the `.score-compose` directory with the [default resource provisioners]({{< relref "/docs/score-implementation/score-compose/resources-provisioners/" >}}) available, plus the Ollama-specific provisioner for the `llm-model` resource type.
 
-The `--patch-templates` option adds the [`ollama.tpl`](https://github.com/score-spec/community-patchers/blob/main/score-compose/ollama.tpl) patcher which configures the Ollama service integration in the generated Docker Compose file.
+The `--patch-templates` option adds the [`ollama.tpl`](https://github.com/score-spec/community-patchers/blob/main/score-compose/ollama.tpl) patch template which configures the Ollama service integration in the generated Docker Compose file.
 
 You can see the resource provisioners available by running this command:
 

--- a/content/en/docs/examples/llm-models.md
+++ b/content/en/docs/examples/llm-models.md
@@ -7,7 +7,7 @@ weight: 8
 
 ## Overview
 
-In this example we will walk you through how you can deploy local LLM models with [Open WebUI](https://github.com/open-webui/open-webui) as the frontend, and this with `score-compose`. We'll cover two approaches to running the LLM models locally: using [Ollama](https://ollama.com/) and using [Docker Model Runner (DMR)](https://docs.docker.com/desktop/features/model-runner/).
+In this example we will walk you through how you can deploy local LLM models with [Open WebUI](https://github.com/open-webui/open-webui) as the frontend, and this with `score-compose`. We'll cover two approaches to run the LLM models locally: using [Ollama](https://ollama.com/) or using [Docker Model Runner (DMR)](https://docs.docker.com/desktop/features/model-runner/).
 
 ```mermaid
 flowchart TD

--- a/content/en/docs/examples/llm-models.md
+++ b/content/en/docs/examples/llm-models.md
@@ -1,0 +1,105 @@
+---
+title: "LLM Models"
+linkTitle: "LLM Models"
+description: "How to deploy local LLM models with Open WebUI using `score-compose`"
+weight: 8
+---
+
+## Overview
+
+In this example we will walk you through how you can deploy local LLM models with [Open WebUI](https://github.com/open-webui/open-webui) as the frontend, and this with `score-compose`. We'll cover two approaches to running the LLM models locally: using [Ollama](https://ollama.com/) and using [Docker Model Runner (DMR)](https://docs.docker.com/desktop/features/model-runner/).
+
+```mermaid
+flowchart TD
+    subgraph Workloads
+        open-webui-workload(Open WebUI)
+    end
+    open-webui-workload-->gemma3[[gemma3 - LLM Model]]
+    open-webui-workload-->smollm2[[smollm2 - LLM Model]]
+    open-webui-workload-->Volume
+```
+
+## Score file
+
+Open your IDE and paste in the following `score.yaml` file, which describes an Open WebUI application that connects to two LLM models (`gemma3` and `smollm2`) and stores its data in a persistent volume.
+
+For the **Ollama** scenario:
+
+```yaml
+apiVersion: score.dev/v1b1
+metadata:
+  name: open-webui
+containers:
+  open-webui:
+    image: .
+    variables:
+      OLLAMA_BASE_URL: "${resources.gemma3.url}"
+    volumes:
+      /app/backend/data:
+        source: ${resources.data}
+resources:
+  data:
+    type: volume
+  gemma3:
+    type: llm-model
+    params:
+      model: gemma3:270m
+  smollm2:
+    type: llm-model
+    params:
+      model: smollm2:135m
+service:
+  ports:
+    tcp:
+      port: 8080
+      targetPort: 8080
+```
+
+For the **Docker Model Runner (DMR)** scenario, the `score.yaml` file is almost identical. The key differences are the model names, which follow the DMR naming convention:
+
+```yaml
+apiVersion: score.dev/v1b1
+metadata:
+  name: open-webui
+containers:
+  open-webui:
+    image: .
+    variables:
+      OLLAMA_BASE_URL: "${resources.smollm2.url}"
+    volumes:
+      /app/backend/data:
+        source: ${resources.data}
+resources:
+  data:
+    type: volume
+  gemma3:
+    type: llm-model
+    params:
+      model: ai/gemma3:270M-UD-IQ2_XXS
+  smollm2:
+    type: llm-model
+    params:
+      model: ai/smollm2:135M-Q2_K
+service:
+  ports:
+    tcp:
+      port: 8080
+      targetPort: 8080
+```
+
+Both files use the `llm-model` resource type to request LLM models. The `score-compose` provisioners handle the underlying infrastructure differences (Ollama container vs Docker Model Runner) transparently.
+
+## Deployment with `score-compose`
+
+From here, we will now see how to deploy this Score file with `score-compose`, using either Ollama or Docker Model Runner as the LLM backend:
+
+{{< tabs name="deployments">}}
+{{< tab name="Ollama" include="./included/llm-models-ollama.md" />}}
+{{< tab name="Docker Model Runner (DMR)" include="./included/llm-models-dmr.md" />}}
+{{< /tabs >}}
+
+## Next steps
+
+- [**Deep dive with the associated blog post**](https://medium.com/google-cloud/score-docker-compose-to-deploy-your-local-llm-models-10aff89686ce): Go through the associated step-by-step blog post to understand the different concepts in more detail.
+- [**Explore more examples**](/examples/): Check out more examples to dive into further use cases and experiment with different configurations.
+- [**Join the Score community**]({{< relref "/docs/community" >}}): Connect with fellow Score developers on our CNCF Slack channel or start find your way to contribute to Score.


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The Examples section currently doesn't have an entry for LLM Models. As discussed in #281, it would be helpful to show how to deploy local LLM models using score-compose, covering both Ollama and Docker Model Runner scenarios.

## What does this change do?

Adds a new "LLM Models" example entry under `content/en/docs/examples/` with three files:

- `llm-models.md` - Main page with overview, mermaid diagram, and score.yaml files for both scenarios
- `included/llm-models-ollama.md` - Step-by-step guide for the Ollama approach
- `included/llm-models-dmr.md` - Step-by-step guide for the Docker Model Runner approach

The content is ported from this blog post: https://medium.com/google-cloud/score-docker-compose-to-deploy-your-local-llm-models-10aff89686ce in a simpler format, following the same structure as the existing examples (Nginx, Backstage, etc.).

## What is your testing strategy?

Verified the markdown structure matches the existing examples. Confirmed that the provisioner and patcher URLs point to valid files in the community-provisioners and community-patchers repos.

## Is this related to any issues?

Closes #281

## Have you read the [Contributing Guidelines](CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
