### PR TITLE
Add --format flag to score-k8s generate CLI reference

### DIFF
--- a/content/en/docs/score implementation/score-k8s/cli.md
+++ b/content/en/docs/score implementation/score-k8s/cli.md
@@ -129,6 +129,14 @@ score-k8s generate [flags]
 
 The `generate` command can be combined with the following flags:
 
+### `--format`
+
+Specifies the output format for the manifests: `yaml` or `kyaml`. By default, the output format is `yaml`.
+
+```bash
+score-k8s generate --format kyaml
+```
+
 ### `--generate-namespace`
 
 Specifies optionally if a `Namespace` resource should be generated in the manifests. Requires `--namespace` to be set.


### PR DESCRIPTION
## What is the motivation?

score-k8s 0.15.0 just shipped a new `--format` flag on the `generate` command (score-spec/score-k8s#321). After that PR was merged, @mathieu-benoit asked me to add the flag to the CLI reference once the release was out: https://github.com/score-spec/score-k8s/pull/321#issuecomment-4879615031. The page doesn't mention it yet, so anyone reading the docs today wouldn't know the flag exists.

## What does this change do?

Adds a `--format` entry to the `generate` flags section of the score-k8s CLI reference. It's a small addition: a one-line description and a bash example, same shape as the other flag entries on that page, placed in alphabetical order before `--generate-namespace`. The wording follows the flag's help text in 0.15.0: the output format can be `yaml` or `kyaml`, and it defaults to `yaml` so nothing changes for anyone who doesn't opt in.

## What is your testing strategy?

Docs-only change, no code. I checked the description against the released flag's `--help` output and kept the markdown consistent with the neighbouring entries so it renders the same way on the page.

## Is this related to any issues?

- score-spec/score-k8s#321 (the PR that added the flag)
- score-spec/score-k8s#198 (the original feature request for KYAML output)

## Have you read the [Contributing Guidelines](CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)